### PR TITLE
update scss using / to divide to use math.div() function

### DIFF
--- a/assets/css/shevy/shevy/_mixins.scss
+++ b/assets/css/shevy/shevy/_mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 ///
 /// Output the headings (h1, h2...) with the calculated settings
 /// @access public
@@ -35,7 +37,7 @@
       }
 
       @if $font-unit-ems-bool {
-        $line-height: line-height-spacing($increment, $settings) / $font-size;
+        $line-height: math.div(line-height-spacing($increment, $settings), $font-size);
       }
       @else {
         $line-height: line-height-spacing($increment, $settings);
@@ -45,7 +47,7 @@
     // Margin Bottom Calculation
     @if $margin-bottom-bool {
       @if $font-unit-ems-bool {
-        $margin-bottom: $base-spacing / $font-size * $base-unit-multiplier;
+        $margin-bottom: math.div($base-spacing, $font-size) * $base-unit-multiplier;
       }
       @else {
         $margin-bottom: $base-spacing;
@@ -101,7 +103,7 @@
   // Margin Bottom
   @if $margin-bottom-bool {
     @if $font-unit-ems-bool {
-      $margin-bottom: $base-spacing / $base-font-size * $base-unit-multiplier;
+      $margin-bottom: math.div($base-spacing, $base-font-size) * $base-unit-multiplier;
     }
     @else {
       $margin-bottom: $base-spacing;


### PR DESCRIPTION
```
Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(line-height-spacing($increment, $settings), $font-size) or calc(line-height-spacing($increment, $settings) / $font-size)

More info and automated migrator: https://sass-lang.com/d/slash-div
```

Updates  `_mixins.scss` functions that use `/` to divide to use `math.div()` since the former will be depreciated and only used as a separator in the future to follow CSS rules.